### PR TITLE
Add pivot table name on methods when needed to avoid collision

### DIFF
--- a/src/Coders/Model/Relations/BelongsToMany.php
+++ b/src/Coders/Model/Relations/BelongsToMany.php
@@ -88,6 +88,9 @@ class BelongsToMany implements Relation
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($tableName);
         }
+        if ($this->needsPivotTable()) {
+            return Str::camel($tableName).'By'.$this->pivot->getClassName();
+        }
 
         return Str::camel($tableName);
     }


### PR DESCRIPTION
This should generate methods like:

```
	public function influencerProfiles(): BelongsToMany
	{
		return $this->belongsToMany(InfluencerProfile::class)
					->withPivot(ChallengeInfluencerProfile::IS_APPROVED);
	}

	public function influencerProfilesByChallengeInfluencerProfileRedirection(): BelongsToMany
	{
		return $this->belongsToMany(InfluencerProfile::class, 'challenge_influencer_profile_redirections')
					->withPivot(ChallengeInfluencerProfileRedirection::ID, ChallengeInfluencerProfileRedirection::URL, ChallengeInfluencerProfileRedirection::IS_ACTIVE, ChallengeInfluencerProfileRedirection::DELETED_AT)
					->withTimestamps();
	}
```
